### PR TITLE
Command help page should look for both "help" and "description"

### DIFF
--- a/pretty_help/pretty_help.py
+++ b/pretty_help/pretty_help.py
@@ -142,8 +142,14 @@ class Paginator:
             command (commands.Command): The command to get help for
             signature (str): The command signature/usage string
         """
+        if command.help:
+            commandhelp = command.help
+        elif command.description:
+            commandhelp = command.description
+        else:
+            commandhelp = None
         page = self._new_page(
-            command.qualified_name, f"{self.prefix}{command.help}{self.suffix}" or ""
+            command.qualified_name, f"{self.prefix}{commandhelp}{self.suffix}" or ""
         )
         if command.aliases:
             aliases = ", ".join(command.aliases)


### PR DESCRIPTION
It should now look for the "help" argument inside the command object and if it does not exist, it will then find the "description" argument. If none of these exist, it will return None.

I really only created this pull request because my bot uses "description" instead of "help".