### PR TITLE
Fix category index on index page

### DIFF
--- a/pretty_help/pretty_help.py
+++ b/pretty_help/pretty_help.py
@@ -189,7 +189,7 @@ class Paginator:
         if include:
             index = self._new_page(title, bot.description or "")
 
-            for page_no, page in enumerate(self._pages, 2):
+            for page_no, page in enumerate(self._pages, 1):
                 index.add_field(
                     name=f"{page_no}) {page.title}",
                     value=f'{self.prefix}{page.description or "No Description"}{self.suffix}',


### PR DESCRIPTION
Fixes #34

How it is displayed now:
![2021-04-16_08h48_34](https://user-images.githubusercontent.com/8732668/114977592-92c81f00-9e90-11eb-9deb-30e5a7a0f99a.png)

How it is displayed after the fix:
![2021-04-16_08h49_35](https://user-images.githubusercontent.com/8732668/114977644-af645700-9e90-11eb-91f9-cf1d64c7ff24.png)
