### PR TITLE
Extend __command_info to append command.usage to command.help

### DIFF
--- a/pretty_help/pretty_help.py
+++ b/pretty_help/pretty_help.py
@@ -139,6 +139,8 @@ class Paginator:
             info += command.description + "\n\n"
         if command.help:
             info += command.help
+        elif command.usage:
+            info += command.usage
         if not info:
             info = "None"
         return info

--- a/pretty_help/pretty_help.py
+++ b/pretty_help/pretty_help.py
@@ -138,9 +138,7 @@ class Paginator:
         if command.description:
             info += command.description + "\n\n"
         if command.help:
-            info += command.help
-        elif command.usage:
-            info += command.usage
+            info += command.help + command.usage
         if not info:
             info = "None"
         return info

--- a/pretty_help/pretty_help.py
+++ b/pretty_help/pretty_help.py
@@ -138,7 +138,7 @@ class Paginator:
         if command.description:
             info += command.description + "\n\n"
         if command.help:
-            info += command.help + command.usage
+            info += command.help + ' ' + command.signature
         if not info:
             info = "None"
         return info


### PR DESCRIPTION
Added command.usage to __command_info
After reading through the code of commands.usage and commands.help @ discord.py, both can act as a single source of help for a command, but the idea is to be command.help(body of the command) + command.usage(arguments).
First commit can be ignored.